### PR TITLE
fix: use `solana_transaction_error` to prevent private usage of enum

### DIFF
--- a/.changeset/use_solana_transaction_error_to_prevent_private_usage_of_enum.md
+++ b/.changeset/use_solana_transaction_error_to_prevent_private_usage_of_enum.md
@@ -1,0 +1,5 @@
+---
+wallet_standard: patch
+---
+
+# Use `solana_transaction_error` to prevent private usage of enum

--- a/crates/wallet_standard/src/error.rs
+++ b/crates/wallet_standard/src/error.rs
@@ -26,7 +26,7 @@ pub enum WalletError {
 	Serde(String),
 	#[cfg(feature = "solana")]
 	#[error(transparent)]
-	Transaction(#[from] solana_transaction::TransactionError),
+	Transaction(#[from] solana_transaction_error::TransactionError),
 	#[error("the requested feature: `{feature}` is not supported for this wallet: `{wallet}`")]
 	UnsupportedFeature { feature: String, wallet: String },
 	#[error("icon type is not supported")]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved transaction error handling in Solana operations for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->